### PR TITLE
add quota usages info

### DIFF
--- a/octavia/api/v2/controllers/base.py
+++ b/octavia/api/v2/controllers/base.py
@@ -197,6 +197,21 @@ class BaseController(pecan.rest.RestController):
                 db_quotas.member = CONF.quotas.default_member_quota
         return db_quotas
 
+    @staticmethod
+    def _to_quota_usages_list(db_quota):
+        """convert quota usages list format"""
+        quota_usages_list = []
+        db_quota_dict = db_quota.to_dict()
+        # delete project_id key from dict
+        del db_quota_dict['project_id']
+        for key in db_quota_dict:
+            if not key.startswith('in_use_'):
+                quota_usages_list.append(data_models.QuotaUsages(
+                    key, db_quota_dict.get(key),
+                    db_quota_dict.get('in_use_%s' % key)
+                ))
+        return quota_usages_list
+
     def _auth_get_all(self, context, project_id):
         # Check authorization to list objects under all projects
         action = '{rbac_obj}{action}'.format(

--- a/octavia/api/v2/types/quotas.py
+++ b/octavia/api/v2/types/quotas.py
@@ -102,3 +102,33 @@ class QuotaAllResponse(base.BaseType):
 class QuotaPUT(base.BaseType):
     """Overall object for quota PUT request."""
     quota = wtypes.wsattr(QuotaBase)
+
+
+class QuotaUsagesBase(base.BaseType):
+    name = wtypes.wsattr(wtypes.StringType(max_length=255))
+    total = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+    used = wtypes.wsattr(wtypes.IntegerType(
+        minimum=consts.MIN_QUOTA, maximum=consts.MAX_QUOTA))
+
+    @classmethod
+    def from_data_model(cls, data_model, children=False):
+        quota = super(QuotaUsagesBase, cls).from_data_model(
+            data_model, children=children)
+        if quota.name == 'healthmonitor':
+            quota.name = 'health_monitor'
+        elif quota.name == 'loadbalancer':
+            quota.name = 'load_balancer'
+        return quota
+
+
+class QuotaUsagesResponse(base.BaseType):
+    quota = wtypes.wsattr([QuotaUsagesBase])
+
+    @classmethod
+    def from_data_model(cls, data_model, children=False):
+        quota_usages_list = QuotaUsagesResponse()
+        quota_usages_list.quota = [
+            QuotaUsagesBase.from_data_model(obj)
+            for obj in data_model]
+        return quota_usages_list

--- a/octavia/common/constants.py
+++ b/octavia/common/constants.py
@@ -725,6 +725,8 @@ RBAC_GET_ALL_GLOBAL = 'get_all-global'
 RBAC_GET_DEFAULTS = 'get_defaults'
 RBAC_GET_STATS = 'get_stats'
 RBAC_GET_STATUS = 'get_status'
+RBAC_USAGES = 'get_usages'
+
 
 # PROVIDERS
 OCTAVIA = 'octavia'

--- a/octavia/common/data_models.py
+++ b/octavia/common/data_models.py
@@ -774,6 +774,14 @@ class Quotas(BaseDataModel):
         self.in_use_pool = in_use_pool
 
 
+class QuotaUsages(BaseDataModel):
+
+    def __init__(self, name=None, total=None, used=None):
+        self.name = name
+        self.total = total
+        self.used = used
+
+
 class Flavor(BaseDataModel):
 
     def __init__(self, id=None, name=None,

--- a/octavia/controller/worker/v2/tasks/database_tasks.py
+++ b/octavia/controller/worker/v2/tasks/database_tasks.py
@@ -995,9 +995,12 @@ class MarkLBActiveInDB(BaseDatabaseTask):
             self._mark_pool_status(listener.default_pool, status)
 
     def _mark_l7policy_status(self, l7policy, status):
+        op_status = (constants.ONLINE if l7policy.enabled
+                     else constants.OFFLINE)
         self.l7policy_repo.update(
             db_apis.get_session(), l7policy.id,
-            provisioning_status=status)
+            provisioning_status=status,
+            operating_status=op_status)
 
         LOG.debug("Marking all l7rules of l7policy %s %s",
                   l7policy.id, status)
@@ -1010,9 +1013,12 @@ class MarkLBActiveInDB(BaseDatabaseTask):
             self._mark_pool_status(l7policy.redirect_pool, status)
 
     def _mark_l7rule_status(self, l7rule, status):
+        op_status = (constants.ONLINE if l7rule.enabled
+                     else constants.OFFLINE)
         self.l7rule_repo.update(
             db_apis.get_session(), l7rule.id,
-            provisioning_status=status)
+            provisioning_status=status,
+            operating_status=op_status)
 
     def _mark_pool_status(self, pool, status):
         self.pool_repo.update(
@@ -1027,9 +1033,12 @@ class MarkLBActiveInDB(BaseDatabaseTask):
             self._mark_member_status(member, status)
 
     def _mark_hm_status(self, hm, status):
+        op_status = (constants.ONLINE if hm.enabled
+                     else constants.OFFLINE)
         self.health_mon_repo.update(
             db_apis.get_session(), hm.id,
-            provisioning_status=status)
+            provisioning_status=status,
+            operating_status=op_status)
 
     def _mark_member_status(self, member, status):
         self.member_repo.update(

--- a/octavia/policies/quota.py
+++ b/octavia/policies/quota.py
@@ -62,6 +62,14 @@ rules = [
         [{'method': 'GET',
           'path': '/v2/lbaas/quotas/{project_id}/default'}]
     ),
+    policy.DocumentedRuleDefault(
+        '{rbac_obj}{action}'.format(rbac_obj=constants.RBAC_QUOTA,
+                                    action=constants.RBAC_USAGES),
+        constants.RULE_API_READ_QUOTA,
+        "Show Usages Quota for a Project",
+        [{'method': 'GET',
+          'path': '/v2/lbaas/quotas/{project_id}/usages'}]
+    ),
 ]
 
 


### PR DESCRIPTION
add octavia quota usages and total api
repair single-create loadbalancer BUG, healthmonitor l7policy and l7rule operating_status is OFFLINE.

"GET /v2.0/lbaas/quotas/dee210ac4617454d9a746fcb236da874/usages HTTP/1.1"
{
    "quota": [{
        "name": "health_monitor",
        "total": 15,
        "used": 1
    }, {
        "name": "load_balancer",
        "total": 15,
        "used": 1
    }, {
        "name": "pool",
        "total": 15,
        "used": 1
    }, {
        "name": "listener",
        "total": 15,
        "used": 1
    }, {
        "name": "member",
        "total": 15,
        "used": 1
    }]
}